### PR TITLE
Components Dependency Injection

### DIFF
--- a/ZEngine.Architecture/Components/Model/GameComponentModel.cs
+++ b/ZEngine.Architecture/Components/Model/GameComponentModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace ZEngine.Architecture.Components.Model;
 
@@ -7,6 +8,7 @@ namespace ZEngine.Architecture.Components.Model;
 /// </summary>
 public abstract class GameComponentModel : IGameComponentModel
 {
+
     /// <inheritdoc />
     public event EventHandler<IGameComponent>? ComponentAdded;
 
@@ -17,6 +19,20 @@ public abstract class GameComponentModel : IGameComponentModel
     /// Dictionary of existing components.
     /// </summary>
     private readonly ConcurrentDictionary<Type, IGameComponent> _components = new();
+    
+    /// <summary>
+    /// Instance of service provider to satisfy component dependencies.
+    /// </summary>
+    private readonly IServiceProvider _serviceProvider;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="serviceProvider"></param>
+    protected GameComponentModel(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
 
     /// <summary>
     /// Gets all components attached to this game object.
@@ -44,7 +60,7 @@ public abstract class GameComponentModel : IGameComponentModel
             throw new ArgumentException($"Component of type {componentType.FullName} already exists.");
         }
 
-        IGameComponent? component = (IGameComponent?) Activator.CreateInstance(componentType);
+        IGameComponent? component = (IGameComponent?) ActivatorUtilities.CreateInstance(_serviceProvider, componentType);
         if (component is null)
         {
             throw new ArgumentException($"Component of type {componentType.FullName} could not be created.");

--- a/ZEngine.Architecture/GameObjects/GameObject.cs
+++ b/ZEngine.Architecture/GameObjects/GameObject.cs
@@ -22,9 +22,10 @@ public class GameObject : GameComponentModel, IGameObject
     /// <summary>
     /// 
     /// </summary>
+    /// <param name="serviceProvider"></param>
     /// <param name="name"></param>
     /// <param name="active"></param>
-    public GameObject(string name = "New Game Object", bool active = false)
+    public GameObject(IServiceProvider serviceProvider, string name = "New Game Object", bool active = false) : base(serviceProvider)
     {
         _messageHandler = new MessageHandler(this);
         Name = name;

--- a/ZEngine.Architecture/ZEngine.Architecture.csproj
+++ b/ZEngine.Architecture/ZEngine.Architecture.csproj
@@ -7,7 +7,7 @@
         <Authors>Jan "Zechy" Zechovský</Authors>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageId>ZEngine.Architecture</PackageId>
-        <Version>0.1.0</Version>
+        <Version>0.1.1</Version>
         <PackageProjectUrl>https://github.com/JZechy/zengine</PackageProjectUrl>
         <PackageLicenseUrl>https://github.com/JZechy/zengine/blob/main/LICENSE</PackageLicenseUrl>
         <RepositoryUrl>https://github.com/JZechy/zengine</RepositoryUrl>
@@ -16,6 +16,7 @@
     <ItemGroup>
         <PackageReference Include="ConcurrentHashSet" Version="1.3.0" />
         <PackageReference Include="FastDeepCloner" Version="1.3.6" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1"/>
     </ItemGroup>
 </Project>

--- a/ZEngine.Core.Game/GameManager.cs
+++ b/ZEngine.Core.Game/GameManager.cs
@@ -71,6 +71,7 @@ public class GameManager : IGameManager
     /// <inheritdoc />
     public void Start()
     {
+        Initialize();
         Task.Run(GameLoop);
     }
 
@@ -94,8 +95,6 @@ public class GameManager : IGameManager
     /// </summary>
     private async void GameLoop()
     {
-        Initialize();
-
         try
         {
             while (!_cancellationTokenSource.IsCancellationRequested)

--- a/ZEngine.Core.Game/ZEngine.Core.Game.csproj
+++ b/ZEngine.Core.Game/ZEngine.Core.Game.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>0.1.0</Version>
+        <Version>0.1.1</Version>
         <PackageProjectUrl>https://github.com/JZechy/zengine</PackageProjectUrl>
         <PackageLicenseUrl>https://github.com/JZechy/zengine/blob/main/LICENSE</PackageLicenseUrl>
         <RepositoryUrl>https://github.com/JZechy/zengine</RepositoryUrl>

--- a/ZEngine.Systems.GameObjects/GameObjectManager.cs
+++ b/ZEngine.Systems.GameObjects/GameObjectManager.cs
@@ -99,6 +99,19 @@ public class GameObjectManager
 
         return FromPrefab(prefab);
     }
+
+    /// <summary>
+    /// Allows to create a game object from a prefab using a fluent API.
+    /// </summary>
+    /// <param name="init">Initialization callback used compose prefab dependencies.</param>
+    /// <returns></returns>
+    public static IGameObject FromPrefab(Action<IPrefab> init)
+    {
+        Prefab prefab = new(Instance._serviceProvider);
+        init.Invoke(prefab);
+
+        return FromPrefab(prefab);
+    }
     
     /// <summary>
     /// Creates a new instance of game object from a prefab.

--- a/ZEngine.Systems.GameObjects/GameObjectManager.cs
+++ b/ZEngine.Systems.GameObjects/GameObjectManager.cs
@@ -19,9 +19,15 @@ public class GameObjectManager
     /// </summary>
     private readonly GameObjectSystem _gameObjectSystem;
 
-    private GameObjectManager(GameObjectSystem gameObjectSystem)
+    /// <summary>
+    /// Service provider is used to be passed to game objects, to satisfy game component dependencies.
+    /// </summary>
+    private readonly IServiceProvider _serviceProvider;
+
+    private GameObjectManager(GameObjectSystem gameObjectSystem, IServiceProvider serviceProvider)
     {
         _gameObjectSystem = gameObjectSystem;
+        _serviceProvider = serviceProvider;
     }
 
     /// <summary>
@@ -40,7 +46,7 @@ public class GameObjectManager
         }
         private set => _objectManager = value;
     }
-    
+
     /// <summary>
     /// Factory method for creating a new instance of <see cref="GameObjectManager"/>.
     /// </summary>
@@ -48,9 +54,10 @@ public class GameObjectManager
     /// Object manager is instantiated by <see cref="GameObjectSystem"/> during its initialization.
     /// </remarks>
     /// <param name="gameObjectSystem"></param>
-    internal static void CreateInstance(GameObjectSystem gameObjectSystem)
+    /// <param name="serviceProvider"></param>
+    internal static void CreateInstance(GameObjectSystem gameObjectSystem, IServiceProvider serviceProvider)
     {
-        Instance = new GameObjectManager(gameObjectSystem);
+        Instance = new GameObjectManager(gameObjectSystem, serviceProvider);
     }
     
     /// <summary>
@@ -59,7 +66,7 @@ public class GameObjectManager
     /// <returns></returns>
     public static IGameObject Create()
     {
-        GameObject gameObject = new("New Game Object", true);
+        GameObject gameObject = new(Instance._serviceProvider, "New Game Object", true);
         Instance._gameObjectSystem.Register(gameObject);
 
         return gameObject;
@@ -72,7 +79,7 @@ public class GameObjectManager
     /// <returns></returns>
     public static IGameObject Create(IGameObject parent)
     {
-        GameObject gameObject = new("New Game Object", true);
+        GameObject gameObject = new(Instance._serviceProvider, "New Game Object", true);
         gameObject.Transform.SetParent(parent.Transform);
         Instance._gameObjectSystem.Register(gameObject);
 
@@ -86,7 +93,7 @@ public class GameObjectManager
     /// <returns></returns>
     public static IGameObject FromPrefab(IPrefab prefab)
     {
-        GameObject gameObject = new()
+        GameObject gameObject = new(Instance._serviceProvider)
         {
             Name = prefab.Name
         };

--- a/ZEngine.Systems.GameObjects/GameObjectManager.cs
+++ b/ZEngine.Systems.GameObjects/GameObjectManager.cs
@@ -1,6 +1,7 @@
 ﻿using ZEngine.Architecture.Components;
 using ZEngine.Architecture.GameObjects;
 using ZEngine.Systems.GameObjects.Prefabs;
+using ZEngine.Systems.GameObjects.Prefabs.Factory;
 
 namespace ZEngine.Systems.GameObjects;
 
@@ -86,6 +87,19 @@ public class GameObjectManager
         return gameObject;
     }
 
+    /// <summary>
+    /// Creates a game object from a prefab factory.
+    /// </summary>
+    /// <param name="prefabFactory"></param>
+    /// <returns></returns>
+    public static IGameObject FromFactory(IPrefabFactory prefabFactory)
+    {
+        Prefab prefab = new(Instance._serviceProvider);
+        prefabFactory.Configure(prefab);
+
+        return FromPrefab(prefab);
+    }
+    
     /// <summary>
     /// Creates a new instance of game object from a prefab.
     /// </summary>

--- a/ZEngine.Systems.GameObjects/GameObjectSystem.cs
+++ b/ZEngine.Systems.GameObjects/GameObjectSystem.cs
@@ -47,10 +47,16 @@ public class GameObjectSystem : IGameSystem
     /// </summary>
     private readonly ILogger<GameObjectSystem> _logger;
 
-    public GameObjectSystem(IEventMediator eventMediator, ILogger<GameObjectSystem> logger)
+    /// <summary>
+    /// Used to satisfy game objects component dependencies.
+    /// </summary>
+    private readonly IServiceProvider _serviceProvider;
+
+    public GameObjectSystem(IEventMediator eventMediator, ILogger<GameObjectSystem> logger, IServiceProvider serviceProvider)
     {
         _eventMediator = eventMediator;
         _logger = logger;
+        _serviceProvider = serviceProvider;
     }
 
     /// <summary>
@@ -69,7 +75,7 @@ public class GameObjectSystem : IGameSystem
     /// <inheritdoc />
     public void Initialize()
     {
-        GameObjectManager.CreateInstance(this);
+        GameObjectManager.CreateInstance(this, _serviceProvider);
     }
 
     /// <inheritdoc />

--- a/ZEngine.Systems.GameObjects/Prefabs/Factory/IPrefabFactory.cs
+++ b/ZEngine.Systems.GameObjects/Prefabs/Factory/IPrefabFactory.cs
@@ -1,0 +1,13 @@
+﻿namespace ZEngine.Systems.GameObjects.Prefabs.Factory;
+
+/// <summary>
+/// Defines an interface for a factory that configures <see cref="IPrefab"/> instances.
+/// </summary>
+public interface IPrefabFactory
+{
+    /// <summary>
+    /// Configures the prefab.
+    /// </summary>
+    /// <param name="prefab"></param>
+    void Configure(IPrefab prefab);
+}

--- a/ZEngine.Systems.GameObjects/Prefabs/Prefab.cs
+++ b/ZEngine.Systems.GameObjects/Prefabs/Prefab.cs
@@ -1,6 +1,5 @@
 ﻿using ZEngine.Architecture.Components;
 using ZEngine.Architecture.Components.Model;
-using ZEngine.Architecture.GameObjects;
 
 namespace ZEngine.Systems.GameObjects.Prefabs;
 
@@ -9,6 +8,14 @@ namespace ZEngine.Systems.GameObjects.Prefabs;
 /// </summary>
 public class Prefab : GameComponentModel, IPrefab
 {
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="serviceProvider"></param>
+    public Prefab(IServiceProvider serviceProvider) : base(serviceProvider)
+    {
+    }
+
     /// <inheritdoc />
     public string Name { get; set; } = "Prefab Clone";
 

--- a/ZEngine.Systems.GameObjects/ZEngine.Systems.GameObjects.csproj
+++ b/ZEngine.Systems.GameObjects/ZEngine.Systems.GameObjects.csproj
@@ -19,7 +19,15 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
+
+
+
+
+
+
     </ItemGroup>
+
+
 
 
 

--- a/ZEngine.Systems.GameObjects/ZEngine.Systems.GameObjects.csproj
+++ b/ZEngine.Systems.GameObjects/ZEngine.Systems.GameObjects.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>0.1.0</Version>
+        <Version>0.1.1</Version>
         <PackageProjectUrl>https://github.com/JZechy/zengine</PackageProjectUrl>
         <PackageLicenseUrl>https://github.com/JZechy/zengine/blob/main/LICENSE</PackageLicenseUrl>
         <RepositoryUrl>https://github.com/JZechy/zengine</RepositoryUrl>

--- a/ZEngine.Tests.Architecture/GameObjects/GameObjectTest.cs
+++ b/ZEngine.Tests.Architecture/GameObjects/GameObjectTest.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using Moq;
 using NUnit.Framework;
 using ZEngine.Architecture.Communication.Messages;
 using ZEngine.Architecture.Components;
@@ -18,7 +19,7 @@ public class GameObjectTest
     [Test]
     public void Test_GameObjectComponent()
     {
-        GameObject gameObject = new("Test", true);
+        GameObject gameObject = new(Mock.Of<IServiceProvider>(), "Test", true);
         
         Transform transform = gameObject.GetRequiredComponent<Transform>();
         transform.GameObject.Should().Be(gameObject);
@@ -36,7 +37,7 @@ public class GameObjectTest
     [Test]
     public void Test_GameObjectComponent_Lifetime()
     {
-        GameObject gameObject = new("Test", true);
+        GameObject gameObject = new(Mock.Of<IServiceProvider>(), "Test", true);
 
         // Initialize the component.
         GameObjectLifetime lifetime = gameObject.AddComponent<GameObjectLifetime>();
@@ -62,7 +63,7 @@ public class GameObjectTest
     [Test]
     public void Test_Activation()
     {
-        GameObject gameObject = new();
+        GameObject gameObject = new(Mock.Of<IServiceProvider>());
         GameObjectLifetime lifetime = gameObject.AddComponent<GameObjectLifetime>();
         lifetime.Awaken.Should().BeFalse();
         lifetime.EnableCalled.Should().BeFalse();

--- a/ZEngine.Tests.Architecture/ZEngine.Tests.Architecture.csproj
+++ b/ZEngine.Tests.Architecture/ZEngine.Tests.Architecture.csproj
@@ -11,6 +11,7 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"/>
+        <PackageReference Include="Moq" Version="4.20.1" />
         <PackageReference Include="NUnit" Version="3.13.3"/>
         <PackageReference Include="NUnit3TestAdapter" Version="4.2.1"/>
         <PackageReference Include="NUnit.Analyzers" Version="3.3.0"/>

--- a/ZEngine.Tests.Systems.GameObjects/GameObjectSystemTest.cs
+++ b/ZEngine.Tests.Systems.GameObjects/GameObjectSystemTest.cs
@@ -19,7 +19,7 @@ public class GameObjectSystemTest
     {
         this.Invoking(x => { _ = GameObjectManager.Instance; }).Should().Throw<InvalidOperationException>();
 
-        GameObjectSystem system = new(Mock.Of<IEventMediator>(), new NullLogger<GameObjectSystem>());
+        GameObjectSystem system = new(Mock.Of<IEventMediator>(), new NullLogger<GameObjectSystem>(), Mock.Of<IServiceProvider>());
         system.Initialize();
 
         GameObjectManager.Instance.Should().NotBeNull();
@@ -31,7 +31,7 @@ public class GameObjectSystemTest
     [Test]
     public void Test_SystemLifetime()
     {
-        GameObjectSystem system = new(Mock.Of<IEventMediator>(), new NullLogger<GameObjectSystem>());
+        GameObjectSystem system = new(Mock.Of<IEventMediator>(), new NullLogger<GameObjectSystem>(), Mock.Of<IServiceProvider>());
         system.Initialize();
 
         IGameObject gameObject = GameObjectManager.Create();

--- a/ZEngine.Tests.Systems.GameObjects/Prefabs/PrefabTest.cs
+++ b/ZEngine.Tests.Systems.GameObjects/Prefabs/PrefabTest.cs
@@ -8,17 +8,21 @@ using ZEngine.Architecture.Components;
 using ZEngine.Architecture.GameObjects;
 using ZEngine.Systems.GameObjects;
 using ZEngine.Systems.GameObjects.Prefabs;
+using ZEngine.Systems.GameObjects.Prefabs.Factory;
 
 namespace ZEngine.Tests.Systems.GameObjects.Prefabs;
 
 public class PrefabTest
 {
+    /// <summary>
+    /// Tests creation of basic prefab.
+    /// </summary>
     [Test]
     public void Test_BasicPrefab()
     {
         GameObjectSystem system = new(Mock.Of<IEventMediator>(), new NullLogger<GameObjectSystem>(), Mock.Of<IServiceProvider>());
         system.Initialize();
-        
+
         Prefab prefab = new(Mock.Of<IServiceProvider>())
         {
             Name = "Testing Prefab"
@@ -30,5 +34,43 @@ public class PrefabTest
 
         Transform prefabTransform = prefab.GetRequiredComponent<Transform>();
         transform.Position.Should().Be(prefabTransform.Position);
+    }
+
+    /// <summary>
+    /// Tests creation of a prefab from a factory.
+    /// </summary>
+    [Test]
+    public void Test_PrefabFactory()
+    {
+        GameObjectSystem system = new(Mock.Of<IEventMediator>(), new NullLogger<GameObjectSystem>(), Mock.Of<IServiceProvider>());
+        system.Initialize();
+
+        Vector3 position = new(10, 15, 20);
+        IGameObject gameObject = GameObjectManager.FromFactory(new TestingPrefabFactory(position));
+        Transform transform = gameObject.GetRequiredComponent<Transform>();
+        
+        transform.Position.Should().Be(position);
+    }
+    
+    /// <summary>
+    /// Implementation of <see cref="IPrefabFactory"/> to test it's capabilities.
+    /// </summary>
+    private class TestingPrefabFactory : IPrefabFactory
+    {
+        /// <summary>
+        /// Predefines position for the factory.
+        /// </summary>
+        private readonly Vector3 _position;
+
+        public TestingPrefabFactory(Vector3 position)
+        {
+            _position = position;
+        }
+
+        /// <inheritdoc />
+        public void Configure(IPrefab prefab)
+        {
+            prefab.AddComponent<Transform>(x => x.Position = _position);
+        }
     }
 }

--- a/ZEngine.Tests.Systems.GameObjects/Prefabs/PrefabTest.cs
+++ b/ZEngine.Tests.Systems.GameObjects/Prefabs/PrefabTest.cs
@@ -16,10 +16,10 @@ public class PrefabTest
     [Test]
     public void Test_BasicPrefab()
     {
-        GameObjectSystem system = new(Mock.Of<IEventMediator>(), new NullLogger<GameObjectSystem>());
+        GameObjectSystem system = new(Mock.Of<IEventMediator>(), new NullLogger<GameObjectSystem>(), Mock.Of<IServiceProvider>());
         system.Initialize();
         
-        Prefab prefab = new()
+        Prefab prefab = new(Mock.Of<IServiceProvider>())
         {
             Name = "Testing Prefab"
         };


### PR DESCRIPTION
Components can mention in their constructors a dependencies to service classes. Added a new ability called `IPrefabFactory`, which helps to overcome Prefab dependency on `IServiceProvider`. In future, this can be rused to creating a prefab caching based on its factory.